### PR TITLE
Added support for multilib packages meant to be updated together

### DIFF
--- a/app/generate_list.py
+++ b/app/generate_list.py
@@ -13,7 +13,8 @@ __license__ = "GPL version 3"
 
 package_provider_name = 'yum'
 
-multilib_pkg = {'glibc': ['i686', 'x86_64'], 'glibc-devel': ['i686', 'x86_64'], 'libgcc': ['i686', 'x86_64']}
+multilib_pkg = {'glibc': ['i686', 'x86_64'], 'glibc-devel': ['i686', 'x86_64'], 'libgcc': ['i686', 'x86_64'],
+                'libstdc++': ['i686', 'x86_64']}
 multi_ver_pkg = ['kernel', 'kernel-core', 'kernel-devel', 'kernel-modules']
 
 

--- a/conf/update-with-puppet.conf-sample
+++ b/conf/update-with-puppet.conf-sample
@@ -21,6 +21,7 @@ work_branch=package_update
 bundle=true
 bundle_list=/etc/update-with-puppet/package_bundle.json
 install_from_cache=false
+install_multilib=true
 merge=true
 pkg_repos=rhel-7-server-rpms
 repo_in_resource=false


### PR DESCRIPTION
Will handle situation where a package is installed in multiple variants (for example i686 and x86_64) and there for should be updated together.
This will be added as part of the Exec (multilib packages were already listed in package_bundle.json).